### PR TITLE
Notification systems functional

### DIFF
--- a/cards/card.gd
+++ b/cards/card.gd
@@ -24,6 +24,7 @@ var targets_required: Dictionary[Model.ObjectTypes, int]
 @export var _frontside: Node
 @export var _description_label: Label
 @export var _costs_hbox: HBoxContainer
+@export var _background_rect: ColorRect
 
 var owning_character:Character #should change this to a reference to the character later
 #endregion
@@ -68,8 +69,8 @@ func value_check() -> bool:
 		if value_man.get_value(each_value_type) >= cost[each_value_type]:
 			pass
 		else:
+			fail_to_play()
 			return false
-			#make card play 'cant be played' animation or sound
 	for each_value_type in cost.keys():
 		value_man.reserve_value(each_value_type, cost[each_value_type])
 	return true
@@ -177,6 +178,14 @@ func highlight_react() -> void:
 	
 func highlight_return():
 	scale = Vector2(1,1)
+	
+func fail_to_play():
+	var new_tween = get_tree().create_tween()
+	new_tween.tween_property(self, "rotation_degrees", 15, Config.animation_speed * 0.1)
+	new_tween.parallel().tween_property(_frontside, "self_modulate", Color("#b82d1d"), Config.animation_speed * 0.1)
+	new_tween.tween_property(self, "rotation_degrees", -15, Config.animation_speed * 0.1)
+	new_tween.parallel().tween_property(_frontside, "self_modulate", Color("#ffffff"), Config.animation_speed * 0.1)
+	new_tween.tween_property(self, "rotation_degrees", 0, Config.animation_speed * 0.1)
 #endregion
 
 #region Private Methods

--- a/cards/card.gd
+++ b/cards/card.gd
@@ -180,7 +180,7 @@ func highlight_return():
 	scale = Vector2(1,1)
 	
 func fail_to_play():
-	var new_tween = get_tree().create_tween()
+	var new_tween = self.create_tween()
 	new_tween.tween_property(self, "rotation_degrees", 15, Config.animation_speed * 0.1)
 	new_tween.parallel().tween_property(_frontside, "self_modulate", Color("#b82d1d"), Config.animation_speed * 0.1)
 	new_tween.tween_property(self, "rotation_degrees", -15, Config.animation_speed * 0.1)

--- a/cards/card.tscn
+++ b/cards/card.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" uid="uid://cq0rkd2f0cx1d" path="res://cards/card.gd" id="1_ivai2"]
 [ext_resource type="PackedScene" uid="uid://ddbf7ide4v43w" path="res://components/focusable/focusable.tscn" id="2_nwofj"]
 
-[node name="Card" type="Control" unique_id=693299294 node_paths=PackedStringArray("_backside", "_frontside", "_description_label", "_costs_hbox")]
+[node name="Card" type="Control" unique_id=693299294 node_paths=PackedStringArray("_backside", "_frontside", "_description_label", "_costs_hbox", "_background_rect")]
 custom_minimum_size = Vector2(50, 75)
 layout_mode = 3
 anchors_preset = 0
@@ -18,6 +18,7 @@ _backside = NodePath("MarginContainer/Back")
 _frontside = NodePath("MarginContainer/Front")
 _description_label = NodePath("MarginContainer/Front/MarginContainer/VBoxContainer/Description")
 _costs_hbox = NodePath("MarginContainer/Front/MarginContainer/VBoxContainer/Costs")
+_background_rect = NodePath("ColorRect")
 
 [node name="ColorRect" type="ColorRect" parent="." unique_id=1177070234]
 layout_mode = 1

--- a/cards/card_manager.gd
+++ b/cards/card_manager.gd
@@ -118,7 +118,7 @@ func _handle_input():
 				hand_pile.ordered_cards[_selected_card_index].play()
 				hand_pile.ordered_cards[_selected_card_index].highlight_return()
 			else:
-				pass
+				Events.missing_values.emit(hand_pile.ordered_cards[_selected_card_index])
 				#card can't be played due to not enough values
 		elif input_man.is_action_just_released(Model.Action.DISCARD):
 			hand_pile.ordered_cards[_selected_card_index].discard()

--- a/cards/card_manager.tscn
+++ b/cards/card_manager.tscn
@@ -29,8 +29,10 @@ theme_override_constants/margin_bottom = 5
 
 [node name="HBoxContainer" type="HBoxContainer" parent="Layout" unique_id=1366182083]
 visible = false
+custom_minimum_size = Vector2(0, 120)
 layout_mode = 2
-size_flags_vertical = 4
+size_flags_vertical = 8
+alignment = 1
 
 [node name="spacer3" type="Control" parent="Layout/HBoxContainer" unique_id=880297745]
 visible = false

--- a/cards/loot_card/loot_card.gd
+++ b/cards/loot_card/loot_card.gd
@@ -5,8 +5,7 @@ func _ready() -> void:
 	target_range_max = 0
 
 func _trigger_play_ability() -> void:
-	print("loot card cannot be played")
-	pass
+	fail_to_play()
 	
 func _trigger_discard_ability() -> void:
 	owning_character.movement += 1

--- a/components/notification_log.gd
+++ b/components/notification_log.gd
@@ -1,0 +1,34 @@
+extends Control
+
+@onready var labels:Array[Label] = [$TextLines/Label1, $TextLines/Label2, $TextLines/Label3, $TextLines/Label4, $TextLines/Label5]
+
+func _ready() -> void:
+	Events.character_damaged.connect(_on_character_damaged)
+	Events.forced_discard.connect(_on_forced_discard)
+	Events.looted_cards.connect(_on_looted_cards)
+	Events.missing_values.connect(_on_missing_values)
+
+func update(new_message_text:String):
+	labels[0].text = labels[1].text
+	labels[1].text = labels[2].text
+	labels[2].text = labels[3].text
+	labels[3].text = labels[4].text
+	labels[4].text = new_message_text
+	
+func _on_character_damaged(_character:Character, amount:int, source):
+	var source_name = "?"
+	if "type" in source:
+		source_name = Model.ObjectTypes.keys()[source.type]
+	update("P" + str(_character.character_id) + " took " + str(amount) + "dmg from " + source_name)
+
+func _on_forced_discard(_character:Character, source):
+	var source_name = "?"
+	if "type" in source:
+		source_name = Model.ObjectTypes.keys()[source.type]
+	update("P" + str(_character.character_id) + " force discard from " + source_name)
+	
+func _on_looted_cards(_character:Character):
+	update("P" + str(_character.character_id) + " looted cards")
+	
+func _on_missing_values(_card:Card):
+	update("P" + str(_card.owning_character.character_id) + " can't play card, missing values")

--- a/components/notification_log.gd.uid
+++ b/components/notification_log.gd.uid
@@ -1,0 +1,1 @@
+uid://bqiggx2u7k5j3

--- a/components/notification_log.tscn
+++ b/components/notification_log.tscn
@@ -1,0 +1,37 @@
+[gd_scene format=3 uid="uid://53fkdoqcq0da"]
+
+[ext_resource type="Script" uid="uid://bqiggx2u7k5j3" path="res://components/notification_log.gd" id="1_dui1h"]
+
+[node name="NotificationLog" type="Control" unique_id=312626902]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_dui1h")
+
+[node name="TextLines" type="VBoxContainer" parent="." unique_id=293521334]
+layout_mode = 0
+offset_right = 136.0
+offset_bottom = 132.0
+
+[node name="Label1" type="Label" parent="TextLines" unique_id=1375016893]
+layout_mode = 2
+text = "Test"
+
+[node name="Label2" type="Label" parent="TextLines" unique_id=1070861663]
+layout_mode = 2
+text = "Test"
+
+[node name="Label3" type="Label" parent="TextLines" unique_id=1524208928]
+layout_mode = 2
+text = "Test"
+
+[node name="Label4" type="Label" parent="TextLines" unique_id=1761422464]
+layout_mode = 2
+text = "Test"
+
+[node name="Label5" type="Label" parent="TextLines" unique_id=1944513594]
+layout_mode = 2
+text = "Test"

--- a/entities/character.gd
+++ b/entities/character.gd
@@ -67,6 +67,7 @@ func bind_pis_machine(input_pis_machine:PlayerInputStateMachine):
 func take_damage(amount:int):
 	health_current -= amount
 	health_changed.emit(self, health_current + amount, health_current)
+	character_sprite.damage_animation()
 	if health_current <= 0:
 		die()
 		

--- a/entities/character.gd
+++ b/entities/character.gd
@@ -34,6 +34,7 @@ func setup_new_character(input_character_id:int, input_state_machine:PlayerInput
 	character_id = input_character_id
 	input_man = InputManager.get_player_input_manager(character_id)
 	pis_machine = input_state_machine
+	Events.looted_cards.connect(_on_looted_card)
 	return self
 
 func bind_screen(input_screen:PlayerScreen):
@@ -68,6 +69,7 @@ func take_damage(amount:int):
 	health_current -= amount
 	health_changed.emit(self, health_current + amount, health_current)
 	character_sprite.damage_animation()
+	character_sprite.play_pop_up("-" + str(amount) + "hp", Color("b82d1d"))
 	if health_current <= 0:
 		die()
 		
@@ -84,6 +86,7 @@ func forced_random_discard(number_of_cards:int):
 		var random_card = my_screen.card_manager.hand_pile.get_random_card()
 		if random_card != null:
 			my_screen.card_manager.discard(my_screen.card_manager.hand_pile.get_random_card())
+	character_sprite.play_pop_up("forced discard: " + str(number_of_cards), Color("b82d1d"))
 
 func end_turn():
 	ended_turn.emit(self)
@@ -139,3 +142,7 @@ func _on_state_machine_switched(old_state:String, new_state:String):
 			Utils.try_get_grid_man().highlight_targettable_tiles(get_my_current_playing_card(), grid_coordinates, 0)
 		if old_state == Model.InputState.TARGET:
 			Utils.try_get_grid_man().clear_highlights(character_id, 0)
+
+func _on_looted_card(_character:Character):
+	if _character == self:
+		character_sprite.play_pop_up("Looted", Color("#d4ff3b"))

--- a/entities/grid_sprite.gd
+++ b/entities/grid_sprite.gd
@@ -62,10 +62,20 @@ func move_remote_camera(new_position:Vector2):
 func set_type(type_to_set:Model.ObjectTypes):
 	type = type_to_set
 	
-func trigger_enter_ability(target:Character):
+func damage_animation():
+	var new_tween = get_tree().create_tween()
+	var previous_color = self.self_modulate
+	new_tween.tween_property(self, "self_modulate", Color("ffffff"), Config.animation_speed * 0.2)
+	new_tween.tween_property(self, "self_modulate", Color("#b82d1d"), Config.animation_speed * 0.5)
+	new_tween.tween_property(self, "self_modulate", Color("ffffff"), Config.animation_speed * 0.2)
+	new_tween.tween_property(self, "self_modulate", Color("#b82d1d"), Config.animation_speed * 0.5)
+	new_tween.tween_property(self, "self_modulate", Color("ffffff"), Config.animation_speed * 0.2)
+	new_tween.tween_property(self, "self_modulate", previous_color, Config.animation_speed)
+	
+func trigger_enter_ability(target:Character): #override for hazards
 	pass
 	
-func trigger_exit_ability(target:Character):
+func trigger_exit_ability(target:Character): #override for hazards
 	pass
 	
 #endregion

--- a/entities/grid_sprite.gd
+++ b/entities/grid_sprite.gd
@@ -63,14 +63,29 @@ func set_type(type_to_set:Model.ObjectTypes):
 	type = type_to_set
 	
 func damage_animation():
-	var new_tween = get_tree().create_tween()
+	var new_tween = self.create_tween()
 	var previous_color = self.self_modulate
+	play_pop_up("damage", Color("b82d1d"))
 	new_tween.tween_property(self, "self_modulate", Color("ffffff"), Config.animation_speed * 0.2)
 	new_tween.tween_property(self, "self_modulate", Color("#b82d1d"), Config.animation_speed * 0.5)
 	new_tween.tween_property(self, "self_modulate", Color("ffffff"), Config.animation_speed * 0.2)
 	new_tween.tween_property(self, "self_modulate", Color("#b82d1d"), Config.animation_speed * 0.5)
 	new_tween.tween_property(self, "self_modulate", Color("ffffff"), Config.animation_speed * 0.2)
 	new_tween.tween_property(self, "self_modulate", previous_color, Config.animation_speed)
+
+func play_pop_up(text:String, _set_color:Color):
+	var new_pop_up_label = Label.new()
+	#new_pop_up_label.visible = false
+	new_pop_up_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	new_pop_up_label.text = text
+	#set theme here maybe?
+	add_child(new_pop_up_label)
+	new_pop_up_label.global_position = self.global_position
+	var new_tween = self.create_tween()
+	new_tween.tween_property(new_pop_up_label, "global_position", self.global_position - Vector2(2,10), Config.animation_speed)
+	new_tween.tween_property(new_pop_up_label, "self_modulate", Color(_set_color), Config.animation_speed)
+	new_tween.tween_property(new_pop_up_label, "self_modulate", Color("ffffff00"), Config.animation_speed)
+	
 	
 func trigger_enter_ability(target:Character): #override for hazards
 	pass

--- a/entities/grid_sprite.gd
+++ b/entities/grid_sprite.gd
@@ -65,7 +65,6 @@ func set_type(type_to_set:Model.ObjectTypes):
 func damage_animation():
 	var new_tween = self.create_tween()
 	var previous_color = self.self_modulate
-	play_pop_up("damage", Color("b82d1d"))
 	new_tween.tween_property(self, "self_modulate", Color("ffffff"), Config.animation_speed * 0.2)
 	new_tween.tween_property(self, "self_modulate", Color("#b82d1d"), Config.animation_speed * 0.5)
 	new_tween.tween_property(self, "self_modulate", Color("ffffff"), Config.animation_speed * 0.2)
@@ -78,14 +77,14 @@ func play_pop_up(text:String, _set_color:Color):
 	#new_pop_up_label.visible = false
 	new_pop_up_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	new_pop_up_label.text = text
-	#set theme here maybe?
+	new_pop_up_label.position = Vector2(self.get_scaled_size().x / 2, 0)
+	new_pop_up_label.self_modulate = Color("ffffff00")
+	#set label theme here maybe?
 	add_child(new_pop_up_label)
-	new_pop_up_label.global_position = self.global_position
 	var new_tween = self.create_tween()
-	new_tween.tween_property(new_pop_up_label, "global_position", self.global_position - Vector2(2,10), Config.animation_speed)
-	new_tween.tween_property(new_pop_up_label, "self_modulate", Color(_set_color), Config.animation_speed)
-	new_tween.tween_property(new_pop_up_label, "self_modulate", Color("ffffff00"), Config.animation_speed)
-	
+	new_tween.tween_property(new_pop_up_label, "position", new_pop_up_label.position - Vector2(0,15), Config.animation_speed)
+	new_tween.parallel().tween_property(new_pop_up_label, "self_modulate", Color(_set_color), Config.animation_speed)
+	new_tween.tween_property(new_pop_up_label, "self_modulate", Color("ffffff00"), Config.animation_speed * 2)
 	
 func trigger_enter_ability(target:Character): #override for hazards
 	pass

--- a/entities/hazard.gd
+++ b/entities/hazard.gd
@@ -9,9 +9,12 @@ func _ready() -> void:
 
 func trigger_enter_ability(target:Character):
 	#override from grid_sprite
-	print("hazard does 2 damage")
-	target.take_damage(2)
+	#print("hazard does 2 damage")
+	var damage = 2
+	target.take_damage(damage)
+	Events.character_damaged.emit(target, damage, self)
 	
 func trigger_exit_ability(target:Character):
 	print("hazard forces 1 random discard")
 	target.forced_random_discard(1)
+	Events.forced_discard.emit(target, self)

--- a/global/Events.gd
+++ b/global/Events.gd
@@ -3,6 +3,7 @@ extends Node
 #region Card
 signal card_played(_card: Card)
 signal card_discarded(_card: Card)
+signal missing_values(_card :Card)
 #endregion
 
 #region Deck
@@ -12,4 +13,10 @@ signal card_removed_from_deck(_card: Card, _deck: Deck)
 
 #region Input State Machine
 signal request_input_state_transition(new_state:String, requesting_character:Character)
+#endregion
+
+#region Character
+signal character_damaged(_character: Character, _amount:int, effect_source)
+signal looted_cards(_character: Character)
+signal forced_discard(_character: Character, effect_source)
 #endregion

--- a/global/config.gd
+++ b/global/config.gd
@@ -6,3 +6,5 @@ const MAX_PLAYER_COUNT = 4
 
 const VALUE_MANAGER_GROUP = 'value_manager'
 const GRID_MANAGER_GROUP = 'grid_manager'
+
+const animation_speed = 1

--- a/scenes/game_scene.gd
+++ b/scenes/game_scene.gd
@@ -7,6 +7,7 @@ enum viewport_names{p1, p2, p3, p4, origin, minimap}
 @export var _player_view_zoom:Vector2 = Vector2(1.6,1.6)
 @export var manual_set_number_of_players:int = 1
 
+@onready var notification_log_scene := preload("res://components/notification_log.tscn")
 @onready var player_screen_scene := preload("res://scenes/player_screen.tscn")
 @onready var player_viewport_scene := preload("res://scenes/player_subviewport.tscn")
 @onready var card_manager_scene: PackedScene = preload("res://cards/card_manager.tscn")
@@ -30,7 +31,11 @@ var _minimap_coord_4p:Vector2
 func _ready() -> void:
 	_tile_size = grid_man.tile_size
 	setup_players()
-	setup_minimap().reparent($PlayerAreas/Control)
+	var minimap:PlayerSubViewport = setup_minimap()
+	minimap.reparent($PlayerAreas/Control)
+	var notif_log = notification_log_scene.instantiate()
+	$PlayerAreas/Control.add_child(notif_log)
+	notif_log.position = Vector2(minimap.position.x, minimap.position.y + _minimap_size.y)
 #endregion
 
 

--- a/scenes/tile.gd
+++ b/scenes/tile.gd
@@ -101,6 +101,8 @@ func pickup_cards(character:Character):
 			var top_card = grid_cards_face_down.take_top_card()
 			top_card.owning_character = character
 			character.my_screen.card_manager.hand_pile.add_card(top_card)
+	if grid_cards_face_up != null || grid_cards_face_down != null:
+		Events.looted_cards.emit(character)
 
 func add_hazard(new_hazard:Hazard) -> bool:
 	if hazard == null:


### PR DESCRIPTION
A log of events now appears below the minimap, displaying the most recent 5 tracked events. A text pop-up is also emitted from character_sprite when 3/4 tracked event types occur. When trying to play a card that is unplayable (loot card) or that there are not enough values to play the card will flash red and wiggle to indicate it can't be played.

The 4 types of tracked events are: character damaged, character forced to discard, card looted by character and card unplayable (due to a property of the card or due to inadequate values)

Closes #65 