### PR TITLE
Resource cards no longer auto picked up

### DIFF
--- a/scenes/tile.gd
+++ b/scenes/tile.gd
@@ -109,9 +109,6 @@ func enter(entering_character:Character):
 	tile_entered.emit(self, entering_character.character_id)
 	if hazard != null:
 		hazard.trigger_enter_ability(entering_character)
-	#if any cards are on the tile in either grid pile they are currently all picked up and added
-	#to the characters hand
-	pickup_cards(entering_character)
 	characters.append(entering_character)
 	Events.tile_entered.emit(self, entering_character)
 


### PR DESCRIPTION
We didn't make a task for this but this PR will make a very simple change that will cause resource cards to no longer be auto-picked up when entering a tile. This is necessary for the refactor to how resource cards will work for many of the cards I have to work on. I think it makes sense to push this to the main branch so it will be live for others to work on their cards too :)