### PR TITLE
fixed multiplayer bug

### DIFF
--- a/cards/card_manager.gd
+++ b/cards/card_manager.gd
@@ -222,9 +222,12 @@ func _on_state_machine_switched(old_state:String, new_state:String):
 				print("empty draw pile, no effect")
 				Events.request_input_state_transition.emit(Model.InputState.MOVE, character)
 		
-func _on_card_played(_card:Card):
+func _on_card_played(card:Card):
+	if card.owning_character != character:
+		return
+		
 	card_being_played = null
-	discard(_card)
+	discard(card)
 	_selected_card_index -= 1
 #endregion
 	


### PR DESCRIPTION
somehow we forgot or accidentally removed a line checking that a card played event belonged to the card manager's player before discarding it